### PR TITLE
Rag-adjust used incorrectly to document usage of widow-adjust

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Set rules for how you want to adjust styles to eliminate widows – or any group
 #### Properties
 `widow-adjust` accepts the style property you want to use to fix your paragraph.
 ```CSS
-rag-adjust: padding-right;
+widow-adjust: padding-right;
 ```
 _Values:_
 * `padding-right` – Increases `padding-right` until the widow is fixed. (Using `box-sizing: border-box;`)


### PR DESCRIPTION
Simple readme change. Based on the block following the example I edited, it definitely seems like the property being discussed is used as `widow-adjust:padding-right;` rather than `rag-adjust:padding-right;` which I'm assuming was just a hold-over from the previous block.
