### PR TITLE
Correct the nomenclature from "glyph(s)" to "character(s)"

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ View `index.html` to see these new properties in action.
 ## Properties
 
 ### Kerning Pairs
-Adjust the space between specific glyphs with a clear syntax. Just type in the two glyphs you want to kern, then the amount space you want.
+Adjust the space between specific characters with a clear syntax. Just type in the two characters you want to kern, then the amount space you want.
 
 #### Properties
-`kerning-pairs` accepts a comma separated list of two glyphs, then the distance you want between them. Accepts positive or negative distances.
+`kerning-pairs` accepts a comma separated list of two characters, then the distance you want between them. Accepts positive or negative distances.
 ```CSS
 kerning-pairs: az 0.02em; 
 ```
-_Values:_ {Any glyph}{Any glyph} {Any distance}{Any CSS unit}
+_Values:_ {Any character}{Any character} {Any distance}{Any CSS unit}
 
 #### Example CSS
 ```CSS

--- a/index.html
+++ b/index.html
@@ -79,17 +79,17 @@
 		<h2>Properties</h2>
 	
 		<h3 id="kerning-pairs">Kerning Pairs</h3>
-		<p>Manually adjust the space between two specific glyphs with a simple syntax. Read more <a href="http://artequalswork.com/posts/manual-kerning/" title="A Manual Kerning Method for the Web on Art=Work">about manual kerning</a> here.</p>
+		<p>Manually adjust the space between two specific characters with a simple syntax. Read more <a href="http://artequalswork.com/posts/manual-kerning/" title="A Manual Kerning Method for the Web on Art=Work">about manual kerning</a> here.</p>
 	
 		<h4>Properties</h4>
-		<p><code>kerning-pairs</code> accepts a comma separated list of two glyphs, then the distance you want between them. Accepts positive or negative distances.</p>
+		<p><code>kerning-pairs</code> accepts a comma separated list of two characters, then the distance you want between them. Accepts positive or negative distances.</p>
 		
 		<figure>
 			<pre>kerning-pairs: az 0.02em;</pre>
 		</figure>
 		
 		<h4>Values</h4>
-		<p><code>{Any glyph}{Any glyph} {Any distance}{Any CSS unit}</code></p>
+		<p><code>{Any character}{Any character} {Any distance}{Any CSS unit}</code></p>
 		
 		<h4>Example CSS</h4>
 		


### PR DESCRIPTION
**Glyphs** and **characters** are different things. See http://scripts.sil.org/IWS-Chapter02
`type.js` calls them glyphs, but they're actually characters.
